### PR TITLE
handle bad request

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -32,6 +32,14 @@ func getNearByTaxis(c *gin.Context) {
 	r := c.Request
 	m,_ := url.ParseQuery(r.URL.RawQuery)
 
+	if _, ok := m["latitude"]; !ok {
+		c.JSON(400, "User Location Missing!!!!!")
+		return
+	}
+	if _, ok := m["longitude"]; !ok {
+		c.JSON(400, "User Location Missing!!!!!")
+		return
+	}
 	userLocation.Latitude = m["latitude"][0]
 	userLocation.Longitude = m["longitude"][0]
 	latitude,_ := strconv.ParseFloat(userLocation.Latitude, 64)


### PR DESCRIPTION
If the api request does not send either latitude or longitude as url query then send bad request status