### PR TITLE
corrects the type of routeId

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -278,7 +278,7 @@ func getRide(c *gin.Context) {
 	r := c.Request
 	m, _ := url.ParseQuery(r.URL.RawQuery)
 
-	routeId := m["routeid"][0]
+	routeId,_ := strconv.Atoi(m["routeid"][0])
 	var userRoute models.Route
 	database.Where("id = ?", routeId).Find(&userRoute)
 


### PR DESCRIPTION
RouteId was initialized as string instead of int, so typecasted it into INT